### PR TITLE
Auto-filter Sales & New In; align navbar/footer widths

### DIFF
--- a/trendywear/app/(site)/components/Footer.tsx
+++ b/trendywear/app/(site)/components/Footer.tsx
@@ -37,7 +37,7 @@ export default function Footer() {
 
   return (
     <footer className="bg-[#c1121f] text-white py-16 border-t border-red-800">
-      <div className="max-w-7xl mx-auto px-8 md:px-4 flex flex-col md:flex-row justify-between gap-8">
+      <div className="max-w-[1600px] mx-auto px-10 md:pl-[6.25rem] flex flex-col items-center text-center md:flex-row  md:text-left md:justify-between gap-8">
 
         {/* Left Section: Brand Info */}
         <div className="flex flex-col justify-center md:w-1/4 md:px-4">
@@ -45,17 +45,17 @@ export default function Footer() {
             Trendy Wear
           </h2>
           <div className="pb-1 border-b border-white/30">
-            <p className="text-sm font-medium tracking-wide">
+            <p className="text-md font-medium tracking-wide">
               The Destination for the Distinguished.
             </p>
           </div>
-          <p className="pt-4 text-xs text-red-100">
+          <p className="pt-4 text-sm text-red-100">
             © 2026 Trendy Wear. All rights reserved.
           </p>
         </div>
 
         {/* Right Section: Navigation Columns */}
-        <div className="flex-1 flex justify-between sm:px-8 md:px-16 lg:px-32">
+        <div className="w-full flex flex-wrap justify-center gap-12 md:w-auto md:flex-1 md:flex-nowrap md:justify-between md:px-16 lg:px-32">
           {footerColumns.map((col, idx) => (
             <div key={idx} className="flex flex-col space-y-6">
               <h3 className="text-[#F59E0B] text-lg font-bold">{col.title}</h3>
@@ -71,14 +71,14 @@ export default function Footer() {
                             router.push(link.href);
                           }
                         }}
-                        className="hover:text-white hover:underline transition text-left w-full"
+                        className="text-md hover:text-white hover:underline transition text-center w-full md:text-left"
                       >
                         {link.label}
                       </button>
                     ) : (
                       <Link
                         href={link.href}
-                        className="hover:text-white hover:underline transition"
+                        className="text-md hover:text-white hover:underline transition"
                       >
                         {link.label}
                       </Link>

--- a/trendywear/app/(site)/components/Navbar.tsx
+++ b/trendywear/app/(site)/components/Navbar.tsx
@@ -169,7 +169,7 @@ export default function Navbar() {
         fixed top-0 left-0 w-full bg-white shadow-2xl z-[100] transition-all duration-300 ease-in-out
         ${isSearchOpen ? 'translate-y-0 opacity-100' : '-translate-y-full opacity-0 pointer-events-none'}
       `}>
-        <div className="max-w-7xl mx-auto px-6 py-8 flex items-center gap-6">
+        <div className="max-w-[1600px] mx-auto px-10 py-8 flex items-center gap-6">
           <form onSubmit={handleSearchSubmit} className="flex-1 flex items-center border-b-2 border-[#003049] py-2">
             <MdOutlineSearch size={30} className="text-[#003049] mr-4" />
             <input
@@ -193,7 +193,7 @@ export default function Navbar() {
         </div>
       </div>
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-8 py-6 flex items-center">
+      <div className="max-w-[1600px] mx-auto px-10 py-6 flex items-center">
 
         {/* Left Links */}
         <div className="hidden lg:flex flex-1 justify-evenly text-[#003049] font-medium text-lg">

--- a/trendywear/app/(site)/lib/fetchProducts.ts
+++ b/trendywear/app/(site)/lib/fetchProducts.ts
@@ -22,7 +22,9 @@ export type SortOption = "name" | "price_asc" | "rating" | null;
 export async function fetchProducts(
     search?: string | null,
     tags?: string | null,
-    sortBy?: SortOption
+    sortBy?: SortOption,
+    createdAfter?: string | Date | null,
+    onSaleOnly: boolean = false
 ): Promise<Product[]> {
     const supabase = createClient();
     const { data: { user } } = await supabase.auth.getUser();
@@ -30,7 +32,7 @@ export async function fetchProducts(
 
     let query = supabase
         .from("items")
-        .select("id, name, image_id, tags")
+        .select("id, name, image_id, tags, created_at")
         .eq("is_active", true);
 
     if (search && search.trim() !== "") {
@@ -41,10 +43,19 @@ export async function fetchProducts(
         query = query.contains("tags", [tags]);
     }
 
+    if (createdAfter) {
+        const cutoffIso =
+            typeof createdAfter === "string"
+                ? createdAfter
+                : createdAfter.toISOString();
+        query = query.gte("created_at", cutoffIso);
+    }
+
     const { data: items, error } = await query;
     if (error || !items) throw error ?? new Error("No items returned");
 
     const itemIds = items.map((i) => i.id);
+    if (itemIds.length === 0) return [];
     const now = new Date().toISOString();
 
     // ✅ Fetch ALL prices per item (to get current + old price)
@@ -129,7 +140,9 @@ export async function fetchProducts(
     else if (sortBy === "rating") mapped.sort((a, b) => b.rating - a.rating);
     else if (sortBy === "name") mapped.sort((a, b) => a.name.localeCompare(b.name));
 
-    return mapped;
+    const saleFiltered = onSaleOnly ? mapped.filter((p) => !!p.oldPrice && p.oldPrice > p.price) : mapped;
+
+    return saleFiltered;
 }
 
 // ✅ Helper: extract unique subcategories from fetched products given a main category

--- a/trendywear/app/(site)/new-in/page.tsx
+++ b/trendywear/app/(site)/new-in/page.tsx
@@ -45,7 +45,8 @@ export default function Page() {
   useEffect(() => {
     setLoading(true);
     setActivePage(1);
-    fetchProducts(searchQuery, activeCategory || null, sortBy)
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    fetchProducts(searchQuery, activeCategory || null, sortBy, cutoff)
       .then(setAllProducts)
       .catch(console.error)
       .finally(() => setLoading(false));

--- a/trendywear/app/(site)/sales/page.tsx
+++ b/trendywear/app/(site)/sales/page.tsx
@@ -56,7 +56,7 @@ function SalesPageContent() {
 
   useEffect(() => {
     setLoading(true);
-    fetchProducts(searchQuery, activeCategory)
+    fetchProducts(searchQuery, activeCategory ?? null, null, null, true)
       .then(setProducts)
       .catch(console.error)
       .finally(() => setLoading(false));


### PR DESCRIPTION
trendywear/app/(site)/lib/fetchProducts.ts - “Add shared Sales + New-In filtering” What changed: Extended fetchProducts to accept createdAfter (filters items.created_at) and onSaleOnly (filters to discounted items where oldPrice > price). Also included created_at in the select. Why: So Sales and New In pages can apply their required “meaning” automatically (sale items only; last-30-days only) without duplicating query logic per page. 

trendywear/app/(site)/sales/page.tsx - “Sales page shows discounted items” What changed: Updated the fetch call to pass onSaleOnly=true. Why: items.tags aren’t “sale” tags, so the correct signal for “on sale” in the  app is pricing (oldPrice > price). 

trendywear/app/(site)/new-in/page.tsx - “New In page shows last 30 days only” What changed: Added a 30-day cutoff date and passed it to fetchProducts as createdAfter. Why: Makes the page consistently show new arrivals by definition, while keeping the existing UI filters. 

trendywear/app/(site)/components/Navbar.tsx - “Match navbar width to page container” What changed: Switched the navbar inner container (and the search overlay container) to use a wider, consistent page-like container (e.g., max-w-[1600px] with px-10). Why: To align the header content with the page grid edges so the site feels consistent across screens. 

trendywear/app/(site)/components/Footer.tsx - “Footer alignment + responsive centering + typography tweaks” What changed: Iterated on footer container width/padding to align with the page edges and navbar, improved small-screen centering behavior, and ensured account links/buttons align correctly when centered. Also enforced footer link text sizing to sm (not xs) where needed. Why: To make footer spacing/edge alignment consistent with the rest of the site and improve readability on all breakpoints.